### PR TITLE
feat(lib): add halo2-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@
 - [Nova](https://github.com/microsoft/Nova)
 - [SnarkyJS](https://github.com/o1-labs/snarkyjs)
 - [DIZK](https://github.com/scipr-lab/dizk)
+- [halo2-lib](https://github.com/axiom-crypto/halo2-lib)
 
 ## Layer1 and Layer2
 ### Layer 1 


### PR DESCRIPTION
halo2-lib provide basic primitives for writing zero-knowledge proof circuits using the [Halo 2](https://zcash.github.io/halo2/) proving stack.A lot of people in the community have been using it lately, and it's a very nice lib